### PR TITLE
Improve the handling when computer locked or UAC prompt raised.

### DIFF
--- a/src/HotCornersWin/FormAbout.Designer.cs
+++ b/src/HotCornersWin/FormAbout.Designer.cs
@@ -61,7 +61,7 @@
             labelVer.Name = "labelVer";
             labelVer.Size = new Size(59, 25);
             labelVer.TabIndex = 1;
-            labelVer.Text = "v0.9.0";
+            labelVer.Text = "v0.9.2";
             // 
             // labelDescription
             // 

--- a/src/HotCornersWin/HotCornersProcessor.cs
+++ b/src/HotCornersWin/HotCornersProcessor.cs
@@ -73,10 +73,17 @@ namespace HotCornersWin
 
         private void OnTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
         {
+            FullscreenState currentFullscreenState = ScreenInfoHelper.GetFullscreenState();
+            // Ignore when the machine is locked or UAC prompt is raised.
+            if (currentFullscreenState is FullscreenState.Undefined or FullscreenState.NotPresent)
+            {
+                return;
+            }
+
             // Disable operation if something's running in a full screen mode.
             if (DisableOnFullscreen)
             {
-                if (ScreenInfoHelper.GetFullscreenState() != FullscreenState.NoFullscreen)
+                if (currentFullscreenState != FullscreenState.NoFullscreen)
                 {
                     if (!_blockStateChanged)
                     {

--- a/src/HotCornersWin/HotCornersWin.csproj
+++ b/src/HotCornersWin/HotCornersWin.csproj
@@ -8,8 +8,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Copyright>Aleksandr Korostelin</Copyright>
     <SignAssembly>False</SignAssembly>
-    <AssemblyVersion>0.9.1</AssemblyVersion>
-    <FileVersion>0.9.1</FileVersion>
+    <AssemblyVersion>0.9.2</AssemblyVersion>
+    <FileVersion>0.9.2</FileVersion>
     <PackageIcon>icons8-layout-96.png</PackageIcon>
     <ApplicationIcon>icon-new-on.ico</ApplicationIcon>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
To fix that LeftTop action is triggered when the computer is locked or a UAC prompt appears, improve the process for getting fullscreen status and the corresponding procedures.